### PR TITLE
Change heading levels in docs

### DIFF
--- a/build/vocab_build_tools.py
+++ b/build/vocab_build_tools.py
@@ -88,7 +88,7 @@ def create_index(categories, merged_df):
     Returns:
         string: index of terms in Markdown format
     """
-    text = '\n### Index of terms\n\n'
+    text = '\n## Index of terms\n\n'
 
     if len(categories) > 1:
         text += '**classes**\n\n'
@@ -293,10 +293,10 @@ def create_vocab(categories, merged_df):
     Returns:
         str: vocabulary in HTML format
     """
-    vocab = '### Vocabulary\n\n'
+    vocab = '## Vocabulary\n\n'
     for category in categories:
         if len(categories) > 1:
-            vocab += '#### {label}\n\n'.format(label=category['label'])
+            vocab += '### {label}\n\n'.format(label=category['label'])
             filtered_df = merged_df[merged_df['organizedInClass']
                                     == category['namespace']]
         else:

--- a/docs/taxon-concept-relationship-type-vocabulary.md
+++ b/docs/taxon-concept-relationship-type-vocabulary.md
@@ -4,11 +4,11 @@
 [tcsTaxonConceptRelationshipType.yaml](./tcsTaxonConceptRelationshipType.yaml) file. Please
 do not edit the markdown directly, but make any changes in the YAML file.
 
-### Index of terms
+## Index of terms
 
 [Taxon Concept Relationship Type Concept Scheme](#tcsreltype_rt) | [Is Congruent With](#tcsreltype_rt001) | [Has proper subset](#tcsreltype_rt002) | [Is Included In](#tcsreltype_rt003) | [partiallyOverlaps](#tcsreltype_rt004) | [Is disjoint from](#tcsreltype_rt005) | [Intersects](#tcsreltype_rt006)
 
-### Vocabulary
+## Vocabulary
 
 <table style="width:100%;">
 	<thead>

--- a/docs/tcs-terms.md
+++ b/docs/tcs-terms.md
@@ -5,7 +5,7 @@
 Please do not edit the markdown directly, but make any changes in the YAML
 files.
 
-### Index of terms
+## Index of terms
 
 **classes**
 
@@ -27,9 +27,9 @@ files.
 
 [tcs:typifiedName](#tcs_typifiedName) | [tcs:typeOfType](#tcs_typeOfType) | [tcs:typeName](#tcs_typeName) | [tcs:typeSpecimen](#tcs_typeSpecimen) | [tcs:typePublishedIn](#tcs_typePublishedIn)
 
-### Vocabulary
+## Vocabulary
 
-#### Taxon Concept
+### Taxon Concept
 
 <table style="width:100%;">
 	<thead>
@@ -357,7 +357,7 @@ files.
 	</tbody>
 </table>
 
-#### Taxon Concept Relationship
+### Taxon Concept Relationship
 
 <table style="width:100%;">
 	<thead>
@@ -603,7 +603,7 @@ files.
 	</tbody>
 </table>
 
-#### Taxon Name
+### Taxon Name
 
 <table style="width:100%;">
 	<thead>
@@ -1294,7 +1294,7 @@ files.
 	</tbody>
 </table>
 
-#### Nomenclatural Type
+### Nomenclatural Type
 
 <table style="width:100%;">
 	<thead>


### PR DESCRIPTION
Make all headings one level higher (in particular h4 to h3) to improve readability. In particular, it was very hard to see where one class in the vocabulary ended and the next one started.

There are no changes to the YAML in this PR, just to the build script.